### PR TITLE
Add descriptions for each command

### DIFF
--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -22,6 +22,26 @@ class CompileCommand extends Command
         $this->logger = $logger;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('maba:webpack:compile')
+            ->setDescription('Compile webpack assets')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command compiles webpack assets.
+
+    <info>%command.full_name%</info>
+
+Pass the --env=prod flag to compile for production.
+
+    <info>%command.full_name% --env=prod</info>
+EOT
+            );
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $logger = $this->logger;

--- a/src/Command/DevServerCommand.php
+++ b/src/Command/DevServerCommand.php
@@ -19,6 +19,22 @@ class DevServerCommand extends Command
         $this->compiler = $compiler;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('maba:webpack:dev-server')
+            ->setDescription('Run a webpack-dev-server as a separate process on localhost:8080')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command runs webpack-dev-server as a separate process, it listens on <info>localhost:8080</info>. By default, assets in development environment are pointed to <info>http://localhost:8080/compiled/*</info>.
+
+    <info>%command.full_name%</info>
+EOT
+            );
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->compiler->compileAndWatch(function($type, $buffer) use ($output) {

--- a/src/Command/SetupCommand.php
+++ b/src/Command/SetupCommand.php
@@ -26,6 +26,24 @@ class SetupCommand extends Command
         $this->configPath = realpath($configPath);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('maba:webpack:setup')
+            ->setDescription('Initial setup for maba webpack bundle')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command copies a default <info>webpack.config.js</info> and <info>package.json</info> files and runs <info>npm install</info>. 
+
+After executing this command, you should commit the following files to your repository.
+
+    <info>git add package.json app/config/webpack.config.js</info>
+EOT
+            );
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         /** @var QuestionHelper $helper */


### PR DESCRIPTION
Added a description for each command for when running `console` by itself.

Before:

![image](https://cloud.githubusercontent.com/assets/1582690/17628848/2f86760e-60af-11e6-9d13-cad4b3408a0a.png)

After:

![image](https://cloud.githubusercontent.com/assets/1582690/17628852/33bdd230-60af-11e6-9e15-27bede338b2b.png)

Same thing for the `console help maba:webpack:dev-server` command (`help`):

Outputs:

```
$ console help maba:webpack:dev-server 
Usage:
  maba:webpack:dev-server

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -e, --env=ENV         The Environment name. [default: "dev"]
      --no-debug        Switches off debug mode.
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
 The maba:webpack:dev-server command runs webpack-dev-server as a separate process, it listens on localhost:8080. By default, assets in development environment are pointed to http://localhost:8080/compiled/*.
 
     ./bin/console maba:webpack:dev-server
```
