### PR TITLE
Update AssetResolver.php

### DIFF
--- a/src/Service/AssetResolver.php
+++ b/src/Service/AssetResolver.php
@@ -41,7 +41,7 @@ class AssetResolver
         $resolvedAsset = implode('!', $assetParts);
 
         if ($this->entryFileManager->isEntryFile($locatedAsset)) {
-            $resolvedAsset = 'extract-file?q=' . urlencode($resolvedAsset) . '!';
+            $resolvedAsset = 'extract-file-loader?q=' . urlencode($resolvedAsset) . '!';
         }
 
         return $resolvedAsset;


### PR DESCRIPTION
in webpack2, the -loader suffix is no longer optional, without it compile fails with an error