### PR TITLE
Update less-loader

### DIFF
--- a/src/Resources/defaultConfig/v2/package.json
+++ b/src/Resources/defaultConfig/v2/package.json
@@ -11,7 +11,7 @@
         "file-loader": "^0.10.1",
         "image-webpack-loader": "^3.2.0",
         "less": "^2.7.2",
-        "less-loader": "^3.0.0",
+        "less-loader": "^4.0.0",
         "node-sass": "^4.5.0",
         "postcss-loader": "^1.3.3",
         "raw-loader": "^0.5.1",


### PR DESCRIPTION
There is a bug in `less-loader@3.x` (one of issues: http://stackoverflow.com/questions/39546191/less-imports-not-working-when-bundled-using-extract-text-plugin-for-webpack)

Basically it leads to many `@headings-font-family is undefined` erros when you compile i.e. bootstrap.