### PR TITLE
Travis CI: Remove HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
       env: COMPOSER_ARGS=""
     - php: 5.6
       env: COMPOSER_ARGS=""
-    - php: hhvm
-      env: COMPOSER_ARGS=""
     - php: 7.0
       env: COMPOSER_ARGS=""
     - php: 7.1
@@ -27,8 +25,6 @@ matrix:
     - php: 5.5
       env: COMPOSER_ARGS="--prefer-lowest"
     - php: 5.6
-      env: COMPOSER_ARGS="--prefer-lowest"
-    - php: hhvm
       env: COMPOSER_ARGS="--prefer-lowest"
     - php: 7.0
       env: COMPOSER_ARGS="--prefer-lowest"
@@ -49,7 +45,6 @@ install:
 
 before_script:
     - phpenv config-rm xdebug.ini || true
-    - if [[ "$TRAVIS_PHP_VERSION" == "hhvm" ]]; then sed -re 's/\s+"friendsofphp\/php-cs-fixer"[^\n]+//g' -i composer.json; fi
     - bash -c "composer update $COMPOSER_ARGS"
 
 script:


### PR DESCRIPTION
HHVM is not supported anymore:

> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.

Source: https://travis-ci.org/mariusbalcytis/webpack-bundle/jobs/241059478