### PR TITLE
Update webpack.config.js

### DIFF
--- a/src/Resources/defaultConfig/v2/webpack.config.js
+++ b/src/Resources/defaultConfig/v2/webpack.config.js
@@ -74,6 +74,7 @@ module.exports = function makeWebpackConfig(options) {
                 warnings: false,
                 errors: true
             },
+            disableHostCheck: true,
             headers: { "Access-Control-Allow-Origin": "*" }
         }, options.parameters.dev_server || {})
     };


### PR DESCRIPTION
This will otherwise result with `Invalid Host header` if the dev-server is run inside a virtual machine and bound to 0.0.0.0. 
This disables the security fix, which is IMO not needed on dev.