### PR TITLE
Add tsx to disabled_extensions

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -132,7 +132,7 @@ class Configuration implements ConfigurationInterface
         $entryFile->booleanNode('enabled')->defaultTrue();
         $entryFile
             ->arrayNode('disabled_extensions')
-            ->defaultValue(array('js', 'jsx', 'ts', 'coffee', 'es6', 'ls'))
+            ->defaultValue(array('js', 'jsx', 'ts', 'tsx', 'coffee', 'es6', 'ls'))
             ->prototype('scalar')
             ->info('For these extensions default webpack functionality will be used')
         ;


### PR DESCRIPTION
Firstly I'd like to say a huge thanks for all your hard work that's gone into this bundle. It's allowing me to pry the legacy assetic service out of our code.

We use Typescript heavily within our React components and as such have a bunch of files with the `tsx` extension. It'd be great to have this extension enabled for webpack by default so I don't have to define all your existing disabled_extensions and tsx in the config file.


