### PR TITLE
Fix space encoding for entry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/_support/_generated
 tests/functional/Fixtures/node_modules
 tests/functional/Fixtures/root_v1/node_modules
 .php_cs.cache
+.idea

--- a/src/Service/AssetResolver.php
+++ b/src/Service/AssetResolver.php
@@ -41,7 +41,7 @@ class AssetResolver
         $resolvedAsset = implode('!', $assetParts);
 
         if ($this->entryFileManager->isEntryFile($locatedAsset)) {
-            $resolvedAsset = 'extract-file-loader?q=' . urlencode($resolvedAsset) . '!';
+            $resolvedAsset = 'extract-file-loader?q=' . rawurlencode($resolvedAsset) . '!';
         }
 
         return $resolvedAsset;

--- a/tests/unit/Service/AssetResolverTest.php
+++ b/tests/unit/Service/AssetResolverTest.php
@@ -53,7 +53,9 @@ class AssetResolverTest extends Test
     {
         return array(
             array('/full/path.js', '/full/path.js', '/full/path.js', '/full/path.js', false),
+            array('/full/path with space.js', '/full/path with space.js', '/full/path with space.js', '/full/path with space.js', false),
             array('extract-file-loader?q=%2Ffull%2Fpath.js!', '/full/path.js', '/full/path.js', '/full/path.js', true),
+            array('extract-file-loader?q=%2Ffull%2Fpath%20with%20space.js!', '/full/path with space.js', '/full/path with space.js', '/full/path with space.js', true),
             array('loader!/full/path.js', 'loader!/full/path.js', '/full/path.js', '/full/path.js', false),
             array(
                 'extract-file-loader?q=loader%21%2Ffull%2Fpath.js!',
@@ -71,6 +73,8 @@ class AssetResolverTest extends Test
             ),
             array('/full/path.js', '@alias/path.js', '@alias/path.js', '/full/path.js', false),
             array('extract-file-loader?q=%2Ffull%2Fpath.js!', '@alias/path.js', '@alias/path.js', '/full/path.js', true),
+            array('extract-file-loader?q=%2Ffull%2Fpath%20with%20space.js!', '@alias/path with space.js', '@alias/path with space.js', '/full/path with space.js', true),
+            array('extract-file-loader?q=%2Falias%20path%20with%2Fspace.js!', '@alias/space.js', '@alias/space.js', '/alias path with/space.js', true),
             array(
                 'extract-file-loader?q=loader%21%2Ffull%2Fpath.js!',
                 'loader!@alias/path.js',


### PR DESCRIPTION
Hey there,

I found an issue when building our assets in a Jenkins job that has a space in the job name.
My project contains a less file which is marked as an included entry file, the AssetResolver wraps the with the `extract-file-loader` but uses the wrong url encoding.

So the working directory of the `maba:webpack:compile` is `/path/to/jenkins/My Job/workspace`. I have a bundle `MyBundle` and a twig file that contains a `webpack_asset('@MyBundle/some.less')` call.

The resulting `app/cache/local/webpack.config.js` contains:
```js
module.exports = require('\/path\/to\/jenkins\/My Job\/workspace\/app\/config\/webpack.config.js')({
    'entry': {
        'some-909503fdcbe6afbde10a0515e94225c45d6f03ea': 'extract-file-loader?q=%2Fpath%2Fto%2Fjenkins%2FMy+Job%2Fworkspace%2Fsrc%2FMyBundle%2F/Resources/some.less!',
    },
    'alias': {
        '@MyBundle': '\/path\/to\/jenkins\/My Job\/workspace\/src\/MyBundle',
    },
});
```

Notice that the space has been replaced with a `+` :(

Running that configuration file then causes the following error in webpack:
```
ERROR in ./node_modules/extract-file-loader?q=%2Fpath%2Fto%2Fjenkins%2FMy+Job%2Fworkspace%2Fsrc%2FMyBundle%2F/Resources/some.less
    Module not found: Error: Can't resolve '/path/to/jenkins/My+Job/workspace/src/MyBundle/Resources/some.less' in '/path/to/jenkins/My Job/workspace'  
    @ ./node_modules/extract-file-loader?q=%2Fpath%2Fto%2Fjenkins%2FMy+Job%2Fworkspace%2Fsrc%2FMyBundle%2F/Resources/some.less 1:17-143
```

I've added a couple of tests to verify the intended behaviour.