### PR TITLE
Enable config file in Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ maba_webpack:
                                             # see inside your webpack.config.js for more info
         # set location of cached manifests. Useful for deploy, when you don't want to include your cache directory
         manifest_file_path:        '%kernel.cache_dir%/webpack_manifest.php'
+        typescript:           false     # is config file in typescript
 
     aliases:                            # allows to set aliases inside require() in your JS files
         path_in_bundle:       /Resources/assets     # this means that require('@acme_hello/a.js')
@@ -384,6 +385,26 @@ maba_webpack:
                 - node
                 - "--max-old-space-size=4096"   # 4GB
                 - node_modules/webpack/bin/webpack.js
+```
+
+## Configuration for config in Typescript
+
+If you want to write your
+[webpack config in Typescript](https://webpack.js.org/configuration/configuration-languages/#typescript), you need to 
+set `maba_webpack.config.typescript` to true. If you want to use a specific `tsconfig.json` file for `ts-node` to run, 
+set the path before webpack binary:
+
+```yml
+maba_webpack:
+    bin:
+        webpack:
+            executable:
+                - 'TS_NODE_PROJECT="%kernel.root_dir%/config/tsconfig.json"'
+                - 'node_modules/.bin/webpack'
+        dev-server:
+            executable:
+                - 'TS_NODE_PROJECT="%kernel.root_dir%/config/tsconfig.json"'
+                - 'node_modules/.bin/webpack-dev-server'
 ```
 
 Using commons chunk

--- a/src/Config/WebpackConfigDumper.php
+++ b/src/Config/WebpackConfigDumper.php
@@ -39,10 +39,11 @@ class WebpackConfigDumper
     public function dump(WebpackConfig $config)
     {
         $configTemplate = 'module.exports = require(%s)(%s);';
-        $configTemplateTS = 'export default require(%s)(%s);';
+        $configTemplateTS = 'import __fn from %s; export default __fn(%s);';
+        $chosenPath = $this->typescript ? $this->tsPath : $this->path;
         $configContents = sprintf(
             $this->typescript ? $configTemplateTS : $configTemplate,
-            json_encode($this->includeConfigPath),
+            json_encode($this->typescript ? preg_replace('/\.tsx?$/i', '', $this->includeConfigPath) : $this->includeConfigPath),
             json_encode([
                 'entry' => (object)$config->getEntryPoints(),
                 'groups' => (object)$config->getAssetGroups(),
@@ -53,8 +54,8 @@ class WebpackConfigDumper
             ])
         );
 
-        file_put_contents($this->typescript ? $this->tsPath : $this->path, $configContents);
+        file_put_contents($chosenPath, $configContents);
 
-        return $this->path;
+        return $chosenPath;
     }
 }

--- a/src/Config/WebpackConfigDumper.php
+++ b/src/Config/WebpackConfigDumper.php
@@ -5,25 +5,31 @@ namespace Maba\Bundle\WebpackBundle\Config;
 class WebpackConfigDumper
 {
     private $path;
+    private $tsPath;
     private $includeConfigPath;
     private $manifestPath;
     private $environment;
     private $parameters;
+    private $typescript;
 
     /**
      * @param string $path full path where config should be dumped
+     * @param string $tsPath full path where config should be dumped in typescript
      * @param string $includeConfigPath path of config to be included inside dumped config
      * @param string $manifestPath
      * @param string $environment
      * @param array $parameters
+     * @param bool $typescript is config in typescript
      */
-    public function __construct($path, $includeConfigPath, $manifestPath, $environment, array $parameters)
+    public function __construct($path, $tsPath, $includeConfigPath, $manifestPath, $environment, array $parameters, $typescript)
     {
         $this->path = $path;
+        $this->tsPath = $tsPath;
         $this->includeConfigPath = $includeConfigPath;
         $this->manifestPath = $manifestPath;
         $this->environment = $environment;
         $this->parameters = $parameters;
+        $this->typescript = $typescript;
     }
 
     /**
@@ -33,8 +39,9 @@ class WebpackConfigDumper
     public function dump(WebpackConfig $config)
     {
         $configTemplate = 'module.exports = require(%s)(%s);';
+        $configTemplateTS = 'export default require(%s)(%s);';
         $configContents = sprintf(
-            $configTemplate,
+            $this->typescript ? $configTemplateTS : $configTemplate,
             json_encode($this->includeConfigPath),
             json_encode([
                 'entry' => (object)$config->getEntryPoints(),
@@ -46,7 +53,7 @@ class WebpackConfigDumper
             ])
         );
 
-        file_put_contents($this->path, $configContents);
+        file_put_contents($this->typescript ? $this->tsPath : $this->path, $configContents);
 
         return $this->path;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -71,6 +71,7 @@ class Configuration implements ConfigurationInterface
         $config->scalarNode('path')->defaultValue('%kernel.project_dir%/config/webpack.config.js');
         $config->arrayNode('parameters')->treatNullLike([])->useAttributeAsKey('name')->prototype('variable');
         $config->scalarNode('manifest_file_path')->defaultValue('%kernel.cache_dir%/webpack_manifest.php');
+        $config->booleanNode('typescript')->defaultValue(false);
     }
 
     private function configureAliases(NodeBuilder $rootChildren)

--- a/src/DependencyInjection/MabaWebpackExtension.php
+++ b/src/DependencyInjection/MabaWebpackExtension.php
@@ -69,6 +69,7 @@ class MabaWebpackExtension extends Extension
         $container->setParameter('maba_webpack.webpack_config_path', $config['config']['path']);
         $container->setParameter('maba_webpack.webpack_config_parameters', $config['config']['parameters']);
         $container->setParameter('maba_webpack.config.manifest_file_path', $config['config']['manifest_file_path']);
+        $container->setParameter('maba_webpack.config.typescript', $config['config']['typescript']);
     }
 
     private function configureAliases(ContainerBuilder $container, $config)

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -29,9 +29,11 @@
         <parameter key="maba_webpack.entry_file.enabled_extensions"/>
         <parameter key="maba_webpack.entry_file.type_map"/>
         <parameter key="maba_webpack.config.manifest_file_path"/>
+        <parameter key="maba_webpack.config.typescript"/>
 
         <!-- Not configurable from config.yml -->
         <parameter key="maba_webpack.webpack_entry_config_path">%kernel.cache_dir%/webpack.config.js</parameter>
+        <parameter key="maba_webpack.webpack_ts_entry_config_path">%kernel.cache_dir%/webpack.config.js</parameter>
         <parameter key="maba_webpack.json_manifest_file_path">%kernel.cache_dir%/webpack_manifest.json</parameter>
     </parameters>
 
@@ -114,10 +116,12 @@
         <service id="maba_webpack.config_dumper" class="Maba\Bundle\WebpackBundle\Config\WebpackConfigDumper"
                  public="false">
             <argument>%maba_webpack.webpack_entry_config_path%</argument>
+            <argument>%maba_webpack.webpack_ts_entry_config_path%</argument>
             <argument>%maba_webpack.webpack_config_path%</argument>
             <argument>%maba_webpack.json_manifest_file_path%</argument>
             <argument>%kernel.environment%</argument>
             <argument>%maba_webpack.webpack_config_parameters%</argument>
+            <argument>%maba_webpack.config.typescript%</argument>
         </service>
 
         <service id="maba_webpack.webpack_config_manager"

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -33,7 +33,7 @@
 
         <!-- Not configurable from config.yml -->
         <parameter key="maba_webpack.webpack_entry_config_path">%kernel.cache_dir%/webpack.config.js</parameter>
-        <parameter key="maba_webpack.webpack_ts_entry_config_path">%kernel.cache_dir%/webpack.config.js</parameter>
+        <parameter key="maba_webpack.webpack_ts_entry_config_path">%kernel.cache_dir%/webpack.config.ts</parameter>
         <parameter key="maba_webpack.json_manifest_file_path">%kernel.cache_dir%/webpack_manifest.json</parameter>
     </parameters>
 

--- a/src/Resources/defaultConfig/latest/package.json
+++ b/src/Resources/defaultConfig/latest/package.json
@@ -1,5 +1,9 @@
 {
     "devDependencies": {
+        "@types/node": "^9.3.0",
+        "@types/webpack": "^3.8.3",
+        "ts-node": "^4.1.0",
+        "tsconfig-paths": "^3.1.1",
         "assets-webpack-plugin": "^3.5.1",
         "autoprefixer": "^6.7.6",
         "babel-core": "^6.23.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR add a way to write and use webpack config file in Typescript. It must be manually enabled like described in the README.
It's a new feature.

**If relevant, link to documentation update:**
https://webpack.js.org/configuration/configuration-languages/#typescript


**Does this PR introduce a breaking change?**
No.

**Other information**
The same kind of work can be made with the other input format : coffee, jsx, and babel.
