### PR TITLE
Webpack 5 compatibility

### DIFF
--- a/src/Service/AssetManager.php
+++ b/src/Service/AssetManager.php
@@ -46,11 +46,14 @@ class AssetManager
 
         $manifestEntry = $this->getManifestEntry($assetName, sprintf('%s (key %s)', $asset, $assetName));
 
-        if ($type === null) {
-            $type = $this->guessFileType($assetName, $asset, $manifestEntry);
+        if (isset($manifestEntry[$type])) {
+            if (is_array($manifestEntry[$type])) {
+                return reset($manifestEntry[$type]);
+            }
+            return $manifestEntry[$type];
         }
 
-        return isset($manifestEntry[$type]) ? $manifestEntry[$type] : null;
+        return null;
     }
 
     /**


### PR DESCRIPTION
With hot update, webpack 5 emits two JS files for single entry-point of which first one is only needed.

![96726600-c848ef80-13ba-11eb-8587-a7003c85cbb7](https://user-images.githubusercontent.com/7325630/96767389-22f74100-13e5-11eb-9d5a-e2851cefa362.png)
